### PR TITLE
Add graceful cli exceptions

### DIFF
--- a/bin/intrinio
+++ b/bin/intrinio
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
 
 require 'intrinio'
-Intrinio::CommandLine.instance.execute ARGV
+
+begin
+  Intrinio::CommandLine.instance.execute ARGV
+rescue Intrinio::BadResponse, Intrinio::IncompatibleResponse => e
+  STDERR.puts "#{e.class} - #{e.message}"
+end

--- a/lib/intrinio/api.rb
+++ b/lib/intrinio/api.rb
@@ -44,9 +44,10 @@ module Intrinio
 
     def get_csv(*args)
       result = get *args
-      
-      raise Intrinio::BadResponse, "Result is not a hash" unless result.is_a? Hash
-      raise Intrinio::IncompatibleResponse, "Result does not contain a data attribute" unless result.has_key? :data
+
+      raise Intrinio::BadResponse, "API said '#{result}'" if result.is_a? String
+      raise Intrinio::BadResponse, "Got a #{result.class},expected a Hash" unless result.is_a? Hash
+      raise Intrinio::IncompatibleResponse, "There is no data attribute in the response" unless result.has_key? :data
       
       data = result[:data]
 

--- a/spec/intrinio/bin_spec.rb
+++ b/spec/intrinio/bin_spec.rb
@@ -12,4 +12,18 @@ describe 'bin/intrinio' do
   it "shows version" do
     expect(`bin/intrinio --version`).to eq "#{VERSION}\n"
   end
+
+  context "with bad response" do
+    it "exits with honor" do
+      command = 'bin/intrinio get --csv historical_data identifier:asd 2>&1'
+      expect(`#{command}`).to eq "Intrinio::BadResponse - API said '400 Bad Request'\n"
+    end
+  end
+
+  context "with incompatible response" do
+    it "exits with honor" do
+      command = 'bin/intrinio get --csv indices identifier:\$FF 2>&1'
+      expect(`#{command}`).to eq "Intrinio::IncompatibleResponse - There is no data attribute in the response\n"
+    end
+  end
 end


### PR DESCRIPTION
When using the `--csv` flag in the command line, in case an exception was raised by [`Intrinio::API#get_csv`][1], the binary did not rescue it and showed the ugly backtrace.

So:

1. The `bin/intrinio` executable now rescues all of our exceptions and exits with honor
2. In addition, the API raise logic was changed a little since we know that if the API returned a string, it is a friendly message (like `400 Bad Request`) - so in this case, we show it to the user instead of raising our generic `BadResponse`


[1]: https://github.com/DannyBen/intrinio/blob/bin-exceptions/lib/intrinio/api.rb#L45