### PR TITLE
Raise an error when receiving nil data

### DIFF
--- a/lib/intrinio/api.rb
+++ b/lib/intrinio/api.rb
@@ -46,8 +46,9 @@ module Intrinio
       result = get *args
 
       raise Intrinio::BadResponse, "API said '#{result}'" if result.is_a? String
-      raise Intrinio::BadResponse, "Got a #{result.class},expected a Hash" unless result.is_a? Hash
+      raise Intrinio::BadResponse, "Got a #{result.class}, expected a Hash" unless result.is_a? Hash
       raise Intrinio::IncompatibleResponse, "There is no data attribute in the response" unless result.has_key? :data
+      raise Intrinio::IncompatibleResponse, "The data attribute in the response is empty" unless result[:data]
       
       data = result[:data]
 

--- a/spec/intrinio/api_spec.rb
+++ b/spec/intrinio/api_spec.rb
@@ -69,6 +69,14 @@ describe API do
         }.to raise_error(IncompatibleResponse)
       end
     end
+
+    context "with a response that has an empty data attribute" do
+      it "raises an error" do
+        expect{
+          intrinio.get_csv :historical_data, identifier:'$CPALTT01USQ661S', item: :change
+        }.to raise_error(IncompatibleResponse)
+      end
+    end
   end
 
   describe '#save_csv' do


### PR DESCRIPTION
`Intrinio::API#get_csv` now handles another case, where `data` attribute is present but `nil`.